### PR TITLE
Move find_package before catkin_python_setup

### DIFF
--- a/robotiq_85_driver/CMakeLists.txt
+++ b/robotiq_85_driver/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robotiq_85_driver)
 
+find_package(catkin REQUIRED COMPONENTS roslaunch rospy)
+
 ## Uncomment if the package has a setup.py
 catkin_python_setup()
-
-find_package(catkin REQUIRED COMPONENTS roslaunch rospy)
 
 catkin_package()
 


### PR DESCRIPTION
find_package must be called before catkin_python_setup for this package to build under all circumstances in noetic: http://wiki.ros.org/catkin/CMakeLists.txt#Overall_Structure_and_Ordering